### PR TITLE
Build script improvements

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -124,6 +124,9 @@ for f in genconfig.sh includes.h blkdev.h blkdev.c snap_device.h tracer.c \
     cp "$PATCHES_DIR/synosnap/$f" "$SNAP_SRC/$f"
 done
 
+info "  Reverting Debian DKMS autoinstall logic..."
+sed -i '/autoinstall/Id' "$SNAP_WORK/repack/DEBIAN/postinst"
+
 # Build the patched synosnap DEB
 PATCHED_SYNOSNAP_DEB="$WORKDIR/synosnap-${SYNOSNAP_VERSION}.deb"
 dpkg-deb --root-owner-group -b "$SNAP_WORK/repack" "$PATCHED_SYNOSNAP_DEB"


### PR DESCRIPTION
This change improves the `build.sh` script by:

1. detecting the line the script from `install.run` ends, which seems to be different, at least for my case using RS-422+
2. allow specifying an alternative `TEMP_DIR` as on servers, `/tmp` might be limited in size 
3. revert the removal of `AUTOTINSTALL="yes"` option from `dkms.conf` by the `postinst` script of the synosnap DEB package, fails to build withouth `AUTOINSTALL="yes"` on Debian 13 (trixie) - kernel 6.12.x