### PR TITLE
Add proper fix reverting Debian DKMS autoinstall

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -125,6 +125,9 @@ for f in genconfig.sh includes.h blkdev.h blkdev.c snap_device.h tracer.c \
     cp "$PATCHES_DIR/synosnap/$f" "$SNAP_SRC/$f"
 done
 
+info "  Reverting Debian DKMS autoinstall logic..."
+sed -i '113,122 s/^/#/' "$SNAP_WORK/repack/DEBIAN/postinst"
+
 # Build the patched synosnap DEB
 PATCHED_SYNOSNAP_DEB="$WORKDIR/synosnap-${SYNOSNAP_VERSION}.deb"
 dpkg-deb --root-owner-group -b "$SNAP_WORK/repack" "$PATCHED_SYNOSNAP_DEB"


### PR DESCRIPTION
Apologies for the breakage you had to revert in a6984fe5f8f094535a90bcc0a22573fbbb160498; it was not properluy tested as I already had the synosnap package installed.

As mentioned there (by Claude Code?) the previous `sed` command left an invalid `if` conditional block which looked like this in the `postinst` file in the DEB package:

```bash
                if [ "$DISTRO" == "debian" ] && [ "$(echo "$DISTROVER >= 12" | bc)" -eq 1 ]; then
                fi
```

This change comments out the whole parent conditional for the Debian 12+ DKMS autoinstall logic, a change which is still needed (this is the part where Claude Code is wrong) otherwise installation will fail with:

```
* Debian 12+ detected, disable DKMS autoinstall
Loading new synosnap/0.11.6 DKMS files...
Not building the synosnap module which does not have AUTOINSTALL enabled.
dpkg: error processing package synosnap (--install):
 installed synosnap package post-installation script subprocess returned error exit status 1
```

So the `postinst` code after commenting out that section will look like this (effectively disabling that section):

```bash
action_configure()
{
        dattobd_version="$(dpkg-query --show --showformat='${Version}' synosnap)"

#       if [ -f /etc/os-release ]; then
#               . /etc/os-release
#               DISTRO=$ID
#               DISTROVER=$VERSION_ID
#               if [ "$DISTRO" == "debian" ] && [ "$(echo "$DISTROVER >= 12" | bc)" -eq 1 ]; then
#                       echo "* Debian 12+ detected, disable DKMS autoinstall"
#                       # ABB #11026 remove AUTOINSTALL="yes" from dkms.conf
#                       sed -i '/AUTOINSTALL="yes"/d' /usr/src/${DATTOBD}-${dattobd_version}/dkms.conf
#               fi
#       fi

        if [ -f /usr/lib/dkms/common.postinst ]; then
                /usr/lib/dkms/common.postinst ${DATTOBD} ${dattobd_version}
        else
```